### PR TITLE
Add atsame5 set-security command to openocd 0.11.0.

### DIFF
--- a/openocd_11/0002-Add-atsame5-set-security-command.patch
+++ b/openocd_11/0002-Add-atsame5-set-security-command.patch
@@ -1,0 +1,66 @@
+From 1c15bfd56a3c646837c0db34a116a898b7994c1f Mon Sep 17 00:00:00 2001
+From: Jeremy Wood <jeremy@bcdevices.com>
+Date: Wed, 22 Sep 2021 17:47:06 -0700
+Subject: [PATCH] Add atsame5 set-security command.
+
+---
+ src/flash/nor/atsame5.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/src/flash/nor/atsame5.c b/src/flash/nor/atsame5.c
+index ed0bef463..49f1e4fa5 100644
+--- a/src/flash/nor/atsame5.c
++++ b/src/flash/nor/atsame5.c
+@@ -826,6 +826,33 @@ COMMAND_HANDLER(same5_handle_userpage_command)
+ 		return res2;
+ }
+ 
++COMMAND_HANDLER(same5_handle_set_security_command)
++{
++	int res = ERROR_OK;
++	struct target *target = get_current_target(CMD_CTX);
++
++	if (CMD_ARGC < 1 || (CMD_ARGC >= 1 && (strcmp(CMD_ARGV[0], "enable")))) {
++		command_print(CMD, "supply the \"enable\" argument to proceed.");
++		return ERROR_COMMAND_SYNTAX_ERROR;
++	}
++
++	if (target) {
++		if (target->state != TARGET_HALTED) {
++			LOG_ERROR("Target not halted");
++			return ERROR_TARGET_NOT_HALTED;
++		}
++
++		res = same5_issue_nvmctrl_command(target, SAME5_NVM_CMD_SSB);
++
++		/* Check (and clear) error conditions */
++		if (res == ERROR_OK)
++			command_print(CMD, "chip secured on next power-cycle");
++		else
++			command_print(CMD, "failed to secure chip");
++	}
++
++	return res;
++}
+ 
+ COMMAND_HANDLER(same5_handle_bootloader_command)
+ {
+@@ -935,6 +962,15 @@ static const struct command_registration same5_exec_command_handlers[] = {
+ 			"For security reasons the reserved-bits are masked out "
+ 			"in background and therefore cannot be changed.",
+ 	},
++	{
++		.name = "set-security",
++		.handler = same5_handle_set_security_command,
++		.mode = COMMAND_EXEC,
++		.help = "Secure the chip's Flash by setting the Security Bit."
++			"This makes it impossible to read the Flash contents."
++			"The only way to undo this is to issue the chip-erase"
++			"command.",
++	},
+ 	COMMAND_REGISTRATION_DONE
+ };
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
This adds a new command to openocd:

`atsame5 set-security enable`

or

`atsame5 set-security disable`