### PR TITLE
Fix nRF9160 mass erase command, enable JLink interface support.

### DIFF
--- a/openocd_nrf9160/0003-Fix-nrf9160-mass-erase.patch
+++ b/openocd_nrf9160/0003-Fix-nrf9160-mass-erase.patch
@@ -1,0 +1,25 @@
+diff --git a/src/flash/nor/nrfx.c b/src/flash/nor/nrfx.c
+index d14a4ac0..4259c428 100644
+--- a/src/flash/nor/nrfx.c
++++ b/src/flash/nor/nrfx.c
+@@ -1417,20 +1417,6 @@ static int nrfx_handle_mass_erase_command(struct command_invocation *cmd,
+ 	if (res != ERROR_OK)
+ 		return res;
+ 
+-	uint32_t ppfc;
+-
+-	res = ficr_read(chip, NRFX_FICR_PPFC, &ppfc);
+-	if (res != ERROR_OK) {
+-		LOG_ERROR("Couldn't read PPFC register");
+-		return res;
+-	}
+-
+-	if ((ppfc & 0xFF) == 0x00) {
+-		LOG_ERROR("Code region 0 size was pre-programmed at the factory, "
+-			  "mass erase command won't work.");
+-		return ERROR_FAIL;
+-	}
+-
+ 	res = nrfx_erase_all(chip);
+ 	if (res != ERROR_OK) {
+ 		LOG_ERROR("Failed to erase the chip");

--- a/openocd_nrf9160/openocd_nrf9160.mk
+++ b/openocd_nrf9160/openocd_nrf9160.mk
@@ -14,6 +14,7 @@ OPENOCD_NRF9160_DEPENDENCIES += libftdi
 
 OPENOCD_NRF9160_CONF_OPTS += --prefix=/usr/local/nrf9160/openocd
 OPENOCD_NRF9160_CONF_OPTS += --enable-ftdi
+OPENOCD_NRF9160_CONF_OPTS += --enable-jlink
 OPENOCD_NRF9160_CONF_OPTS += --disable-doxygen-html
 OPENOCD_NRF9160_CONF_OPTS += --includedir=$(STAGING_DIR)/usr/include/libusb-1.0
 OPENOCD_NRF9160_CONF_OPTS += --with-jim-shared=no


### PR DESCRIPTION
The portion removed from nrfx_handle_mass_erase_command() is only applicable on nRF51, is gated on more recent nRF5x code based on chip type, but since we're only using this for nRF9160 it's most expedient just to tear it out.