### PR TITLE
PLTOS-41 - revert openocd cypress and fix build for aarch64

### DIFF
--- a/openocd_cypress/openocd_cypress.hash
+++ b/openocd_cypress/openocd_cypress.hash
@@ -1,3 +1,3 @@
 #Locally computed
-sha256 eed0d1be00cdf475121b31f0b3edfea4ce119a8f5bea7ffbcbad380cf0c3a312  openocd_cypress-release-v4.3.1-br1.tar.gz
+sha256 ef28f88f6bdfc50480e7a7e0ec3b6ff38d61df1ece1294278836fcdd16a53899  openocd_cypress-release-v4.1.0-br1.tar.gz
 

--- a/openocd_cypress/openocd_cypress.mk
+++ b/openocd_cypress/openocd_cypress.mk
@@ -28,7 +28,7 @@ OPENOCD_CYPRESS_CONF_OPTS += --disable-internal-jimtcl
 OPENOCD_CYPRESS_CONF_OPTS += --disable-shared 
 
 
-OPENOCD_CYPRESS_BIN_ARCH_EXCLUDE = usr/local/cypress/openocd/share/openocd/flm/cypress/traveo2 usr/local/cypress/openocd/share/openocd/flm/cypress/psoc6
+OPENOCD_CYPRESS_BIN_ARCH_EXCLUDE = usr/local/cypress/openocd/share/openocd/flm/cypress/
 
 define OPENOCD_CYPRESS_BOOTSTRAP
 	rm -rf $(@D)/src/jtag/drivers/libjaylink

--- a/openocd_cypress/openocd_cypress.mk
+++ b/openocd_cypress/openocd_cypress.mk
@@ -40,21 +40,6 @@ OPENOCD_CYPRESS_CONF_OPTS = \
 	--enable-cmsis-dap 
 
 
-# Avoid documentation rebuild. On PowerPC64(le), we patch the
-# configure script. Due to this, the version.texi files gets
-# regenerated, and then since it has a newer date than openocd.info,
-# openocd build system rebuilds the documentation. Unfortunately, this
-# documentation rebuild fails on old machines. We work around this by
-# faking the date of the generated version.texi file, to make the
-# build system believe the documentation doesn't need to be
-# regenerated.
-define OPENOCD_CYPRESS_FIX_VERSION_TEXI
-	touch -r $(@D)/doc/openocd.info $(@D)/doc/version.texi
-endef
-
-OPENOCD_CYPRESS_POST_BUILD_HOOKS += OPENOCD_CYPRESS_FIX_VERSION_TEXI
-HOST_OPENOCD_CYPRESS_POST_BUILD_HOOKS += OPENOCD_CYPRESS_FIX_VERSION_TEXI
-
 define OPENOCD_CYPRESS_TARGET_RENAME
 	mv $(TARGET_DIR)/usr/bin/openocd $(TARGET_DIR)/usr/bin/openocd_cypress
 endef

--- a/openocd_cypress/openocd_cypress.mk
+++ b/openocd_cypress/openocd_cypress.mk
@@ -8,38 +8,59 @@ OPENOCD_CYPRESS_VERSION = release-v4.3.1
 OPENOCD_CYPRESS_SITE = git://github.com/Infineon/openocd.git
 OPENOCD_CYPRESS_GIT_SUBMODULES = YES
 
+OPENOCD_CYPRESS_LICENSE = GPL-2.0+
+OPENOCD_CYPRESS_LICENSE_FILES = COPYING
+# 0002-configure-enable-build-on-uclinux.patch patches configure.ac
 OPENOCD_CYPRESS_AUTORECONF = YES
 OPENOCD_CYPRESS_CONF_ENV = CFLAGS="$(TARGET_CFLAGS) -std=gnu99"
-OPENOCD_CYPRESS_DEPENDENCIES = libusb-compat
-OPENOCD_CYPRESS_DEPENDENCIES += libftdi
-OPENOCD_CYPRESS_DEPENDENCIES += hidapi
-OPENOCD_CYPRESS_DEPENDENCIES += jimtcl
 
-OPENOCD_CYPRESS_CONF_OPTS += --prefix=/usr/local/cypress/openocd
-OPENOCD_CYPRESS_CONF_OPTS += --enable-ftdi
-OPENOCD_CYPRESS_CONF_OPTS += --disable-doxygen-html
-OPENOCD_CYPRESS_CONF_OPTS += --enable-cmsis-dap
-OPENOCD_CYPRESS_CONF_OPTS += --enable-jlink
-OPENOCD_CYPRESS_CONF_OPTS += --enable-kitprog
-OPENOCD_CYPRESS_CONF_OPTS += --includedir=$(STAGING_DIR)/usr/include/libusb-1.0
-OPENOCD_CYPRESS_CONF_OPTS += --enable-dummy
-OPENOCD_CYPRESS_CONF_OPTS += --disable-werror
-OPENOCD_CYPRESS_CONF_OPTS += --disable-internal-jimtcl 
-OPENOCD_CYPRESS_CONF_OPTS += --disable-shared 
+OPENOCD_CYPRESS_DEPENDENCIES = \
+	host-pkgconf \
+	jimtcl \
+	libftdi1 \
+	libusb \
+	libusb-compat \
+	libhid \
+	hidapi \
+	libgpiod
+
+# Adapters
+OPENOCD_CYPRESS_CONF_OPTS = \
+	--oldincludedir=$(STAGING_DIR)/usr/include \
+	--includedir=$(STAGING_DIR)/usr/include \
+	--disable-doxygen-html \
+	--disable-internal-jimtcl \
+	--disable-shared \
+	--enable-dummy \
+	--disable-werror \
+	--prefix=/usr/local/cypress/openocd \
+	--enable-ftdi \
+	--enable-jlink \
+  --enable-kitprog \
+	--enable-cmsis-dap 
 
 
-OPENOCD_CYPRESS_BIN_ARCH_EXCLUDE = usr/local/cypress/openocd/share/openocd/flm/cypress/
-
-define OPENOCD_CYPRESS_BOOTSTRAP
-	rm -rf $(@D)/src/jtag/drivers/libjaylink
-	git -C $(@D)/src/jtag/drivers clone http://repo.or.cz/r/libjaylink.git
+# Avoid documentation rebuild. On PowerPC64(le), we patch the
+# configure script. Due to this, the version.texi files gets
+# regenerated, and then since it has a newer date than openocd.info,
+# openocd build system rebuilds the documentation. Unfortunately, this
+# documentation rebuild fails on old machines. We work around this by
+# faking the date of the generated version.texi file, to make the
+# build system believe the documentation doesn't need to be
+# regenerated.
+define OPENOCD_CYPRESS_FIX_VERSION_TEXI
+	touch -r $(@D)/doc/openocd.info $(@D)/doc/version.texi
 endef
+
+OPENOCD_CYPRESS_POST_BUILD_HOOKS += OPENOCD_CYPRESS_FIX_VERSION_TEXI
+HOST_OPENOCD_CYPRESS_POST_BUILD_HOOKS += OPENOCD_CYPRESS_FIX_VERSION_TEXI
 
 define OPENOCD_CYPRESS_TARGET_RENAME
 	mv $(TARGET_DIR)/usr/bin/openocd $(TARGET_DIR)/usr/bin/openocd_cypress
 endef
 
-OPENOCD_CYPRESS_PRE_PATCH_HOOKS += OPENOCD_CYPRESS_BOOTSTRAP
 OPENOCD_CYPRESS_POST_INSTALL_TARGET_HOOKS += OPENOCD_CYPRESS_TARGET_RENAME
+
+OPENOCD_CYPRESS_BIN_ARCH_EXCLUDE = usr/local/cypress/openocd/share/openocd/flm/cypress/
 
 $(eval $(autotools-package))

--- a/openocd_cypress/openocd_cypress.mk
+++ b/openocd_cypress/openocd_cypress.mk
@@ -3,9 +3,8 @@
 # openocd-cypress
 #
 ################################################################################
-
-OPENOCD_CYPRESS_VERSION = release-v4.3.1
-OPENOCD_CYPRESS_SITE = git://github.com/Infineon/openocd.git
+OPENOCD_CYPRESS_VERSION = release-v4.1.0
+OPENOCD_CYPRESS_SITE = git://github.com/cypresssemiconductorco/openocd.git
 OPENOCD_CYPRESS_GIT_SUBMODULES = YES
 
 OPENOCD_CYPRESS_LICENSE = GPL-2.0+

--- a/openocd_cypress/openocd_cypress.mk
+++ b/openocd_cypress/openocd_cypress.mk
@@ -17,12 +17,12 @@ OPENOCD_CYPRESS_CONF_ENV = CFLAGS="$(TARGET_CFLAGS) -std=gnu99"
 OPENOCD_CYPRESS_DEPENDENCIES = \
 	host-pkgconf \
 	jimtcl \
-	libftdi1 \
-	libusb \
-	libusb-compat \
-	libhid \
-	hidapi \
-	libgpiod
+	$(if $(BR2_PACKAGE_LIBFTDI1),libftdi1) \
+	$(if $(BR2_PACKAGE_LIBUSB),libusb) \
+	$(if $(BR2_PACKAGE_LIBUSB_COMPAT),libusb-compat) \
+	$(if $(BR2_PACKAGE_LIBHID),libhid) \
+	$(if $(BR2_PACKAGE_HIDAPI),hidapi) \
+	$(if $(BR2_PACKAGE_LIBGPIOD),libgpiod)
 
 # Adapters
 OPENOCD_CYPRESS_CONF_OPTS = \


### PR DESCRIPTION
- Fix architecture detection for openocd cypress
- Revert openocd cypress version to release-v4.1.0
