### PR TITLE
Revert changes to use  avrdude 7.2

### DIFF
--- a/avrdude_ly/0001-avrftdi-empty-range.patch
+++ b/avrdude_ly/0001-avrftdi-empty-range.patch
@@ -1,0 +1,17 @@
+--- a/avrftdi.c	2019-09-16 12:04:41.000000000 -0700
++++ b/avrftdi.c	2019-09-16 14:41:40.000000000 -0700
+@@ -982,6 +982,14 @@
+ 	unsigned char *buffer = &m->buf[addr];
+ 	unsigned char buf[4*len+4], *bufptr = buf;
+
++	// Skip ranges that are all-0xFF
++	for(poll_index = addr+len-1; poll_index > addr-1; poll_index--)
++		if(m->buf[poll_index] != 0xff)
++			break;
++	if (poll_index < addr ) {
++		return 0;
++	}
++
+ 	memset(buf, 0, sizeof(buf));
+
+ 	/* pre-check opcodes */

--- a/avrdude_ly/avrdude_ly.hash
+++ b/avrdude_ly/avrdude_ly.hash
@@ -1,4 +1,3 @@
 # Locally computed
-sha256  29f69e5e2b561a902fd167cb588caebc184e4e1365560dd62a53e7815687c176  avrdude_ly-v7.2-br1.tar.gz
-
+sha256  3f605a314dc3ea3bca4c1bcb6b60cf4218fe2231f364dc39653229bb8a885d2f  avrdude_ly-9cb8d9b-br1.tar.gz
 

--- a/avrdude_ly/avrdude_ly.mk
+++ b/avrdude_ly/avrdude_ly.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-AVRDUDE_LY_VERSION = v7.2
-AVRDUDE_LY_SITE = git://github.com/avrdudes/avrdude.git
+AVRDUDE_LY_VERSION = 9cb8d9b
+AVRDUDE_LY_SITE = git://github.com/bcdevices/avrdude
 AVRDUDE_LY_LICENSE = GPL-2.0+
 AVRDUDE_LY_LICENSE_FILES = COPYING
 # Sources coming from git, without generated configure and Makefile.in


### PR DESCRIPTION
Looks like I didn't catch the change to CMake. Will need additional changes before avrdude 7.2 can be built.