### PR TITLE
Fix avrdude autoconf

### DIFF
--- a/avrdude_ly/avrdude_ly.mk
+++ b/avrdude_ly/avrdude_ly.mk
@@ -21,6 +21,8 @@ else ifeq ($(BR2_PACKAGE_LIBFTDI),y)
 AVRDUDE_LY_DEPENDENCIES += libftdi
 endif
 
+AVRDUDE_LY_SUBDIR = src
+
 # Autoreconf requires an m4 directory to exist
 define AVRDUDE_LY_PATCH_M4
 	mkdir -p $(@D)/m4


### PR DESCRIPTION
Builds locally again. Using autoreconf and setting the subdir for avrdude.