### PR TITLE
target/ti-cjtag: make switching to JTAG more reliable

### DIFF
--- a/openocd_12/0002-ti-cjtag-fix.patch
+++ b/openocd_12/0002-ti-cjtag-fix.patch
@@ -1,0 +1,12 @@
+diff --git forkSrcPrefix/tcl/target/ti-cjtag.cfg forkDstPrefix/tcl/target/ti-cjtag.cfg
+index d5e13e269a06b09185edd4953345b3d01751d02a..97111f1cc44e4d2e521ce794a208949b4f6ab16c 100644
+--- forkSrcPrefix/tcl/target/ti-cjtag.cfg
++++ forkDstPrefix/tcl/target/ti-cjtag.cfg
+@@ -5,6 +5,7 @@
+ # Read section 6.3 in http://www.ti.com/lit/pdf/swru319 for more information.
+ proc ti_cjtag_to_4pin_jtag {jrc} {
+ 	# Bypass
++	runtest 20
+ 	irscan $jrc 0x3f -endstate RUN/IDLE
+ 	# Two zero bit scans and a one bit drshift
+ 	pathmove RUN/IDLE DRSELECT DRCAPTURE DREXIT1 DRPAUSE


### PR DESCRIPTION
From upstream: https://review.openocd.org/c/openocd/+/7419